### PR TITLE
IPv6 fix and enhancement

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -51,7 +51,7 @@ func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
 	}
 
 	targetAddr := Opts.TargetAddr6
-	if AddrVersion(conn.RemoteAddr()) == 4 {
+	if AddrVersion(saddr) == 4 {
 		targetAddr = Opts.TargetAddr4
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -69,7 +69,7 @@ func DialUpstreamControl(sport int) func(string, string, syscall.RawConn) error 
 			}
 
 			if network == "tcp6" || network == "udp6" {
-				syscallErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IPV6_V6ONLY, 0)
+				syscallErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IPV6, syscall.IPV6_V6ONLY, 0)
 				if syscallErr != nil {
 					syscallErr = fmt.Errorf("setsockopt(IPPROTO_IP, IPV6_ONLY, 0): %s", syscallErr.Error())
 					return


### PR DESCRIPTION
This fixes IPv6 connections (protocol not available) and allows
 "tunneled" 6-in-4 connections between haproxy and go-mmproxy.