### PR TITLE
add option for per-client/per-connection bandwidth limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ See [Go's Getting Started](https://golang.org/doc/install) if your package manag
 
 - on the same server as the proxy target, as the communication happens over the loopback interface;
 - as root or with `CAP_NET_ADMIN` capability to be able to set `IP_TRANSPARENT` socket opt.
+- `sudo setcap 'cap_net_admin=+ep' go-mmproxy`
 
 ## Running
 
@@ -75,6 +76,12 @@ Example invocation:
 
 ```shell
 sudo ./go-mmproxy -l 0.0.0.0:25577 -4 127.0.0.1:25578 -6 [::1]:25578 --allowed-subnets ./path-prefixes.txt
+```
+
+
+```shell
+sudo setcap 'cap_net_admin=+ep' go-mmproxy
+./go-mmproxy -l 0.0.0.0:25565 -4 127.0.0.1:25560 -6 [::1]:25560 -mark 123 -raw -rxrate 102400 -txrate 102400
 ```
 
 ## Benchmark

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ sudo ./go-mmproxy -l 0.0.0.0:25577 -4 127.0.0.1:25578 -6 [::1]:25578 --allowed-s
 
 
 ```shell
-sudo setcap 'cap_net_admin=+ep' go-mmproxy
+sudo setcap 'cap_net_admin=+ep cap_net_bind_service=+ep' go-mmproxy
 ./go-mmproxy -l 0.0.0.0:25565 -4 127.0.0.1:25560 -6 [::1]:25560 -mark 123 -raw -rxrate 102400 -txrate 102400
 ```
 

--- a/go-mmproxy.service.example
+++ b/go-mmproxy.service.example
@@ -5,17 +5,24 @@ After=network.target
 [Service]
 Type=simple
 LimitNOFILE=65535
-ExecStartPost=/sbin/ip rule add from 127.0.0.1/8 iif lo table 123
-ExecStartPost=/sbin/ip route add local 0.0.0.0/0 dev lo table 123
-ExecStartPost=/sbin/ip -6 rule add from ::1/128 iif lo table 123
-ExecStartPost=/sbin/ip -6 route add local ::/0 dev lo table 123
+CapabilityBoundingSet=CAP_NET_BIND_SERVICE CAP_NET_ADMIN
+ExecStartPost=+/sbin/ip rule add from 127.0.0.1/8 iif lo table 123
+ExecStartPost=+/sbin/ip route add local 0.0.0.0/0 dev lo table 123
+ExecStartPost=+/sbin/ip -6 rule add from ::1/128 iif lo table 123
+ExecStartPost=+/sbin/ip -6 route add local ::/0 dev lo table 123
 ExecStart=/usr/bin/go-mmproxy -4 127.0.0.1:1000 -6 "[::1]:1000" -allowed-subnets /usr/share/path-prefixes.txt -l 0.0.0.0:1234
-ExecStopPost=/sbin/ip rule del from 127.0.0.1/8 iif lo table 123
-ExecStopPost=/sbin/ip route del local 0.0.0.0/0 dev lo table 123
-ExecStopPost=/sbin/ip -6 rule del from ::1/128 iif lo table 123
-ExecStopPost=/sbin/ip -6 route del local ::/0 dev lo table 123
+ExecStopPost=+/sbin/ip rule del from 127.0.0.1/8 iif lo table 123
+ExecStopPost=+/sbin/ip route del local 0.0.0.0/0 dev lo table 123
+ExecStopPost=+/sbin/ip -6 rule del from ::1/128 iif lo table 123
+ExecStopPost=+/sbin/ip -6 route del local ::/0 dev lo table 123
 Restart=on-failure
 RestartSec=10s
+User=nobody
+Group=nogroup
+Environment=USER=nobody HOME=/tmp
+ProtectSystem=true
+PrivateTmp=true
+WorkingDirectory=/tmp
 
 [Install]
 WantedBy=multi-user.target

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/path-network/go-mmproxy
 
 go 1.14
 
-require go.uber.org/zap v1.15.0
+require (
+	github.com/juju/ratelimit v1.0.1
+	go.uber.org/zap v1.15.0
+)

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/juju/ratelimit v1.0.1 h1:+7AIFJVQ0EQgq/K9+0Krm7m530Du7tIz0METWzN0RgY=
+github.com/juju/ratelimit v1.0.1/go.mod h1:qapgC/Gy+xNh9UxzV13HGGl/6UXNN+ct+vwSgWNm/qk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/main.go
+++ b/main.go
@@ -29,6 +29,11 @@ type options struct {
 	Logger             *zap.Logger
 	udpCloseAfter      int
 	UDPCloseAfter      time.Duration
+
+	RawProxy           bool // use directly, for per-client bandwidth limiter
+	// bytes per sec, <= 0 disable
+	RatelimitProxyRx   int // per-client upload bandwidth limit
+	RatelimitProxyTx   int // per-client download bandwidth limit
 }
 
 var Opts options
@@ -47,6 +52,9 @@ func init() {
 	flag.IntVar(&Opts.Listeners, "listeners", 1,
 		"Number of listener sockets that will be opened for the listen address (Linux 3.9+)")
 	flag.IntVar(&Opts.udpCloseAfter, "close-after", 60, "Number of seconds after which UDP socket will be cleaned up")
+	flag.BoolVar(&Opts.RawProxy, "raw", false, "use directly as a per-client bandwidth limiter")
+	flag.IntVar(&Opts.RatelimitProxyRx, "rxrate", -1, "bytes per sec, per-client upload bandwidth limit")
+	flag.IntVar(&Opts.RatelimitProxyTx, "txrate", -1, "bytes per sec, per-client download bandwidth limit")
 }
 
 func listen(listenerNum int, errors chan<- error) {

--- a/tcp.go
+++ b/tcp.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 
+	"github.com/juju/ratelimit"
 	"go.uber.org/zap"
 )
 
@@ -17,7 +18,82 @@ func tcpCopyData(dst net.Conn, src net.Conn, ch chan<- error) {
 	ch <- err
 }
 
-func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
+type SpeedCtrl struct {
+	net.Conn
+
+	rbucket   *ratelimit.Bucket
+	wbucket   *ratelimit.Bucket
+}
+
+func (c *SpeedCtrl) Read(data []byte) (n int, err error)  {
+	n, err = c.Conn.Read(data)
+	if n <= 0 {
+		return n, err
+	}
+	if c.rbucket != nil {
+		c.rbucket.Wait(int64(n))
+	}
+	return n, err
+}
+
+func (c *SpeedCtrl) Write(data []byte) (n int, err error) {
+	if c.wbucket != nil {
+		c.wbucket.Wait(int64(len(data)))
+	}
+	return c.Conn.Write(data)
+}
+
+func (c *SpeedCtrl) GetTCPConn() (*net.TCPConn, bool) {
+	conn, ok := c.Conn.(*net.TCPConn)
+	return conn, ok
+}
+
+func NewSpeedCtrl(conn net.Conn, rx int, rxBurst int, tx int, txBurst int) net.Conn {
+	c := &SpeedCtrl{}
+	c.Conn = conn
+	if rx > 0 {
+		if rxBurst < 0 {
+			rxBurst = 0
+		}
+		c.rbucket = ratelimit.NewBucketWithRate(float64(rx), int64(rxBurst))
+	}
+	if tx > 0 {
+		if txBurst < 0 {
+			txBurst = 0
+		}
+		c.wbucket = ratelimit.NewBucketWithRate(float64(tx), int64(txBurst))
+	}
+	return c
+}
+
+type AddrFn func(conn net.Conn, logger *zap.Logger) (net.Addr, net.Addr, []byte, error)
+
+func getProxyAddr(conn net.Conn, logger *zap.Logger) (net.Addr, net.Addr, []byte, error) {
+	buffer := GetBuffer()
+	defer PutBuffer(buffer)
+
+	n, err := conn.Read(buffer)
+	if err != nil {
+		logger.Debug("failed to read PROXY header", zap.Error(err), zap.Bool("dropConnection", true))
+		return nil, nil, nil, err
+	}
+
+	saddr, daddr, restBytes, err := PROXYReadRemoteAddr(buffer[:n], TCP)
+	if err != nil {
+		logger.Debug("failed to parse PROXY header", zap.Error(err), zap.Bool("dropConnection", true))
+		return nil, nil, nil, err
+	}
+
+	return saddr, daddr, restBytes, err
+}
+
+func getRawAddr(conn net.Conn, logger *zap.Logger) (net.Addr, net.Addr, []byte, error) {
+	saddr := conn.RemoteAddr()
+	daddr := conn.LocalAddr()
+	return saddr, daddr, nil, nil
+}
+
+func tcpHandleConnection(conn net.Conn, logger *zap.Logger, getAddr AddrFn) {
 	defer conn.Close()
 	logger = logger.With(zap.String("remoteAddr", conn.RemoteAddr().String()),
 		zap.String("localAddr", conn.LocalAddr().String()))
@@ -31,37 +107,23 @@ func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
 		logger.Debug("new connection")
 	}
 
-	buffer := GetBuffer()
-	defer func() {
-		if buffer != nil {
-			PutBuffer(buffer)
-		}
-	}()
-
-	n, err := conn.Read(buffer)
+	saddr, _, restBytes, err := getAddr(conn, logger)
 	if err != nil {
-		logger.Debug("failed to read PROXY header", zap.Error(err), zap.Bool("dropConnection", true))
+		logger.Debug("failed to get source address", zap.Error(err), zap.Bool("dropConnection", true))
 		return
-	}
-
-	saddr, _, restBytes, err := PROXYReadRemoteAddr(buffer[:n], TCP)
-	if err != nil {
-		logger.Debug("failed to parse PROXY header", zap.Error(err), zap.Bool("dropConnection", true))
-		return
-	}
-
-	targetAddr := Opts.TargetAddr6
-	if AddrVersion(saddr) == 4 {
-		targetAddr = Opts.TargetAddr4
 	}
 
 	clientAddr := "UNKNOWN"
 	if saddr != nil {
 		clientAddr = saddr.String()
 	}
+	targetAddr := Opts.TargetAddr6
+	if AddrVersion(saddr) == 4 {
+		targetAddr = Opts.TargetAddr4
+	}
 	logger = logger.With(zap.String("clientAddr", clientAddr), zap.String("targetAddr", targetAddr))
 	if Opts.Verbose > 1 {
-		logger.Debug("successfully parsed PROXY header")
+		logger.Debug("successfully parsed get source address")
 	}
 
 	dialer := net.Dialer{LocalAddr: saddr}
@@ -79,7 +141,18 @@ func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
 		logger.Debug("successfully established upstream connection")
 	}
 
-	if err := conn.(*net.TCPConn).SetNoDelay(true); err != nil {
+	var tcpConn *net.TCPConn
+	switch v := conn.(type) {
+	case *net.TCPConn:
+		tcpConn = v
+	case *SpeedCtrl:
+		tcpConn, _ = v.GetTCPConn()
+	default:
+		logger.Debug("failed case connection type")
+		return
+	}
+
+	if err := tcpConn.SetNoDelay(true); err != nil {
 		logger.Debug("failed to set nodelay on downstream connection", zap.Error(err), zap.Bool("dropConnection", true))
 	} else if Opts.Verbose > 1 {
 		logger.Debug("successfully set NoDelay on downstream connection")
@@ -100,9 +173,6 @@ func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
 		}
 		restBytes = restBytes[n:]
 	}
-
-	PutBuffer(buffer)
-	buffer = nil
 
 	outErr := make(chan error, 2)
 	go tcpCopyData(upstreamConn, conn, outErr)
@@ -125,6 +195,11 @@ func TCPListen(listenConfig *net.ListenConfig, logger *zap.Logger, errors chan<-
 		return
 	}
 
+	addrFn := getProxyAddr
+	if Opts.RawProxy {
+		addrFn = getRawAddr
+	}
+
 	logger.Info("listening")
 
 	for {
@@ -135,6 +210,12 @@ func TCPListen(listenConfig *net.ListenConfig, logger *zap.Logger, errors chan<-
 			return
 		}
 
-		go tcpHandleConnection(conn, logger)
+		if Opts.RatelimitProxyRx > 0 || Opts.RatelimitProxyTx > 0 {
+			rx := Opts.RatelimitProxyRx
+			tx := Opts.RatelimitProxyTx
+			conn = NewSpeedCtrl(conn, rx, rx * 8, tx, tx * 16)
+		}
+
+		go tcpHandleConnection(conn, logger, addrFn)
 	}
 }


### PR DESCRIPTION
As title,
can limit bandwidth for each connection,
and add a `-raw` mode if someone just want to limit bandwidth yet not to use any HAProxy in case.
ps. I use it for my minecraft server to prevent some player using up all my upload bandwidth if they kept teleport/flying/fast-moving.
