### PR TITLE
Nul saddr segfault

### DIFF
--- a/tcp.go
+++ b/tcp.go
@@ -51,12 +51,11 @@ func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
 	}
 
 	targetAddr := Opts.TargetAddr6
-	if AddrVersion(saddr) == 4 {
-		targetAddr = Opts.TargetAddr4
-	}
-
 	clientAddr := "UNKNOWN"
 	if saddr != nil {
+		if AddrVersion(saddr) == 4 {
+			targetAddr = Opts.TargetAddr4
+		}
 		clientAddr = saddr.String()
 	}
 	logger = logger.With(zap.String("clientAddr", clientAddr), zap.String("targetAddr", targetAddr))

--- a/tcp.go
+++ b/tcp.go
@@ -51,6 +51,10 @@ func tcpHandleConnection(conn net.Conn, logger *zap.Logger) {
 	}
 
 	targetAddr := Opts.TargetAddr6
+	if targetAddr == "" {
+		targetAddr = Opts.TargetAddr4
+	}
+
 	clientAddr := "UNKNOWN"
 	if saddr != nil {
 		if AddrVersion(saddr) == 4 {

--- a/udp.go
+++ b/udp.go
@@ -93,6 +93,9 @@ func udpGetSocketFromMap(downstream net.PacketConn, downstreamAddr, saddr net.Ad
 	}
 
 	targetAddr := Opts.TargetAddr6
+	if targetAddr == "" {
+		targetAddr = Opts.TargetAddr4
+	}
 	if AddrVersion(downstreamAddr) == 4 {
 		targetAddr = Opts.TargetAddr4
 	}


### PR DESCRIPTION
Heyo!

I ran into a couple issues that are specific to my situation.  First, it seems like when `// LOCAL` is hit in `proxyprotocol.go` we end up with a `nul` saddr.  The first commit moves it into the place where it checks if saddr is not nill.

The second problem is that it's impossible to then use on a box without IPv6, so I added to default case a check if it is empty (only when explicitly set with `-6 ""`) it will skip IPv6 and default to IPv4.