### PR TITLE
Add IPv6 routes to example service

### DIFF
--- a/go-mmproxy.service.example
+++ b/go-mmproxy.service.example
@@ -7,9 +7,13 @@ Type=simple
 LimitNOFILE=65535
 ExecStartPost=/sbin/ip rule add from 127.0.0.1/8 iif lo table 123
 ExecStartPost=/sbin/ip route add local 0.0.0.0/0 dev lo table 123
+ExecStartPost=/sbin/ip -6 rule add from ::1/128 iif lo table 123
+ExecStartPost=/sbin/ip -6 route add local ::/0 dev lo table 123
 ExecStart=/usr/bin/go-mmproxy -4 127.0.0.1:1000 -6 "[::1]:1000" -allowed-subnets /usr/share/path-prefixes.txt -l 0.0.0.0:1234
 ExecStopPost=/sbin/ip rule del from 127.0.0.1/8 iif lo table 123
 ExecStopPost=/sbin/ip route del local 0.0.0.0/0 dev lo table 123
+ExecStopPost=/sbin/ip -6 rule del from ::1/128 iif lo table 123
+ExecStopPost=/sbin/ip -6 route del local ::/0 dev lo table 123
 Restart=on-failure
 RestartSec=10s
 


### PR DESCRIPTION
This is necessary for the example since it says `-6 "[::1]:1000"` and IPv6 connections would not work properly if these lines were not present.