### PR TITLE
add -dynamic-destination flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Usage of ./go-mmproxy:
     	Path to a file that contains allowed subnets of the proxy servers
   -close-after int
     	Number of seconds after which UDP socket will be cleaned up (default 60)
+  -dynamic-destination
+        Traffic will be forwarded to the destination specified in the PROXY protocol header
   -l string
     	Address the proxy listens on (default "0.0.0.0:8443")
   -listeners int

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type options struct {
 	Logger             *zap.Logger
 	udpCloseAfter      int
 	UDPCloseAfter      time.Duration
+	DynamicDestination bool
 }
 
 var Opts options
@@ -47,6 +48,7 @@ func init() {
 	flag.IntVar(&Opts.Listeners, "listeners", 1,
 		"Number of listener sockets that will be opened for the listen address (Linux 3.9+)")
 	flag.IntVar(&Opts.udpCloseAfter, "close-after", 60, "Number of seconds after which UDP socket will be cleaned up")
+	flag.BoolVar(&Opts.DynamicDestination, "dynamic-destination", false, "Traffic will be forwarded to the destination specified in the PROXY protocol header")
 }
 
 func listen(listenerNum int, errors chan<- error) {


### PR DESCRIPTION
Hi!

We've a setup where multiple services should be available in the destination host. This flag allow the client to select the desired port in the PROXY protocol header.

Of course, the client should be trusted for this to work without security issues (in our case, its our frontal TCP reverse-proxy).

Any comment is welcome, and thanks for this helpful little tool! ;)