### PR TITLE
Use net/netip to check for ipv4

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"flag"
 	"log/slog"
 	"net"
+	"net/netip"
 	"os"
 	"syscall"
 	"time"
@@ -122,6 +123,21 @@ func main() {
 
 	if Opts.Listeners < 1 {
 		Opts.Logger.Error("--listeners has to be >= 1")
+		os.Exit(1)
+	}
+
+	if _, err := netip.ParseAddr(Opts.ListenAddr); err != nil {
+		Opts.Logger.Error("listen address is malformed", "error", err)
+		os.Exit(1)
+	}
+
+	if _, err := netip.ParseAddr(Opts.TargetAddr4); err != nil {
+		Opts.Logger.Error("ipv4 target address is malformed", "error", err)
+		os.Exit(1)
+	}
+
+	if _, err := netip.ParseAddr(Opts.TargetAddr6); err != nil {
+		Opts.Logger.Error("ipv6 target address is malformed", "error", err)
 		os.Exit(1)
 	}
 

--- a/tcp.go
+++ b/tcp.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"log/slog"
 	"net"
+	"net/netip"
 )
 
 func tcpCopyData(dst net.Conn, src net.Conn, ch chan<- error) {
@@ -51,10 +52,10 @@ func tcpHandleConnection(conn net.Conn, logger *slog.Logger) {
 
 	targetAddr := Opts.TargetAddr6
 	if saddr == nil {
-		if AddrVersion(conn.RemoteAddr()) == 4 {
+		if netip.MustParseAddr(conn.RemoteAddr().String()).Is4() {
 			targetAddr = Opts.TargetAddr4
 		}
-	} else if AddrVersion(saddr) == 4 {
+	} else if netip.MustParseAddr(saddr.String()).Is4() {
 		targetAddr = Opts.TargetAddr4
 	}
 

--- a/udp.go
+++ b/udp.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"log/slog"
 	"net"
+	"net/netip"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -93,7 +94,7 @@ func udpGetSocketFromMap(downstream net.PacketConn, downstreamAddr, saddr net.Ad
 	}
 
 	targetAddr := Opts.TargetAddr6
-	if AddrVersion(downstreamAddr) == 4 {
+	if netip.MustParseAddr(downstreamAddr.String()).Is4() {
 		targetAddr = Opts.TargetAddr4
 	}
 

--- a/utils.go
+++ b/utils.go
@@ -7,7 +7,6 @@ package main
 import (
 	"fmt"
 	"net"
-	"strings"
 	"syscall"
 )
 
@@ -86,12 +85,4 @@ func DialUpstreamControl(sport int) func(string, string, syscall.RawConn) error 
 		}
 		return syscallErr
 	}
-}
-
-func AddrVersion(addr net.Addr) int {
-	// poor man's ipv6 check - golang makes it unnecessarily hard
-	if strings.ContainsRune(addr.String(), '.') {
-		return 4
-	}
-	return 6
 }


### PR DESCRIPTION
This removes one helper func and relies on stdlib implementation of the IPv4 check