### PR TITLE
unexport most func

### DIFF
--- a/main.go
+++ b/main.go
@@ -65,9 +65,9 @@ func listen(listenerNum int, errors chan<- error) {
 	}
 
 	if Opts.Protocol == "tcp" {
-		TCPListen(&listenConfig, logger, errors)
+		tcpListen(&listenConfig, logger, errors)
 	} else {
-		UDPListen(&listenConfig, logger, errors)
+		udpListen(&listenConfig, logger, errors)
 	}
 }
 

--- a/tcp.go
+++ b/tcp.go
@@ -22,7 +22,7 @@ func tcpHandleConnection(conn net.Conn, logger *slog.Logger) {
 	logger = logger.With(slog.String("remoteAddr", conn.RemoteAddr().String()),
 		slog.String("localAddr", conn.LocalAddr().String()))
 
-	if !CheckOriginAllowed(conn.RemoteAddr().(*net.TCPAddr).IP) {
+	if !checkOriginAllowed(conn.RemoteAddr().(*net.TCPAddr).IP) {
 		logger.Debug("connection origin not in allowed subnets", slog.Bool("dropConnection", true))
 		return
 	}
@@ -44,7 +44,7 @@ func tcpHandleConnection(conn net.Conn, logger *slog.Logger) {
 		return
 	}
 
-	saddr, _, restBytes, err := PROXYReadRemoteAddr(buffer[:n], TCP)
+	saddr, _, restBytes, err := proxyReadRemoteAddr(buffer[:n], TCP)
 	if err != nil {
 		logger.Debug("failed to parse PROXY header", "error", err, slog.Bool("dropConnection", true))
 		return
@@ -70,7 +70,7 @@ func tcpHandleConnection(conn net.Conn, logger *slog.Logger) {
 
 	dialer := net.Dialer{LocalAddr: saddr}
 	if saddr != nil {
-		dialer.Control = DialUpstreamControl(saddr.(*net.TCPAddr).Port)
+		dialer.Control = dialUpstreamControl(saddr.(*net.TCPAddr).Port)
 	}
 	upstreamConn, err := dialer.Dial("tcp", targetAddr)
 	if err != nil {
@@ -120,7 +120,7 @@ func tcpHandleConnection(conn net.Conn, logger *slog.Logger) {
 	}
 }
 
-func TCPListen(listenConfig *net.ListenConfig, logger *slog.Logger, errors chan<- error) {
+func tcpListen(listenConfig *net.ListenConfig, logger *slog.Logger, errors chan<- error) {
 	ctx := context.Background()
 	ln, err := listenConfig.Listen(ctx, "tcp", Opts.ListenAddr)
 	if err != nil {

--- a/udp.go
+++ b/udp.go
@@ -102,7 +102,7 @@ func udpGetSocketFromMap(downstream net.PacketConn, downstreamAddr, saddr net.Ad
 	dialer := net.Dialer{LocalAddr: saddr}
 	if saddr != nil {
 		logger = logger.With(slog.String("clientAddr", saddr.String()))
-		dialer.Control = DialUpstreamControl(saddr.(*net.UDPAddr).Port)
+		dialer.Control = dialUpstreamControl(saddr.(*net.UDPAddr).Port)
 	}
 
 	if Opts.Verbose > 1 {
@@ -130,7 +130,7 @@ func udpGetSocketFromMap(downstream net.PacketConn, downstreamAddr, saddr net.Ad
 	return udpConn, nil
 }
 
-func UDPListen(listenConfig *net.ListenConfig, logger *slog.Logger, errors chan<- error) {
+func udpListen(listenConfig *net.ListenConfig, logger *slog.Logger, errors chan<- error) {
 	ctx := context.Background()
 	ln, err := listenConfig.ListenPacket(ctx, "udp", Opts.ListenAddr)
 	if err != nil {
@@ -154,12 +154,12 @@ func UDPListen(listenConfig *net.ListenConfig, logger *slog.Logger, errors chan<
 			continue
 		}
 
-		if !CheckOriginAllowed(remoteAddr.(*net.UDPAddr).IP) {
+		if !checkOriginAllowed(remoteAddr.(*net.UDPAddr).IP) {
 			logger.Debug("packet origin not in allowed subnets", slog.String("remoteAddr", remoteAddr.String()))
 			continue
 		}
 
-		saddr, _, restBytes, err := PROXYReadRemoteAddr(buffer[:n], UDP)
+		saddr, _, restBytes, err := proxyReadRemoteAddr(buffer[:n], UDP)
 		if err != nil {
 			logger.Debug("failed to parse PROXY header", "error", err, slog.String("remoteAddr", remoteAddr.String()))
 			continue

--- a/utils.go
+++ b/utils.go
@@ -17,7 +17,7 @@ const (
 	UDP
 )
 
-func CheckOriginAllowed(remoteIP net.IP) bool {
+func checkOriginAllowed(remoteIP net.IP) bool {
 	if len(Opts.AllowedSubnets) == 0 {
 		return true
 	}
@@ -30,7 +30,7 @@ func CheckOriginAllowed(remoteIP net.IP) bool {
 	return false
 }
 
-func DialUpstreamControl(sport int) func(string, string, syscall.RawConn) error {
+func dialUpstreamControl(sport int) func(string, string, syscall.RawConn) error {
 	return func(network, address string, c syscall.RawConn) error {
 		var syscallErr error
 		err := c.Control(func(fd uintptr) {


### PR DESCRIPTION
As this is not meant to be used as a library, there is no need to export funcs or variables. Unexport them.