### PR TITLE
use buffer pool on two-way relay

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -37,23 +37,33 @@ func DialUpstreamControl(sport int) func(string, string, syscall.RawConn) error 
 			if Opts.Protocol == "tcp" {
 				syscallErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP, syscall.TCP_SYNCNT, 2)
 				if syscallErr != nil {
+					//TCP_SYNCNT:SYN retransmission count set to 2, speed up the detection of connection failures
 					syscallErr = fmt.Errorf("setsockopt(IPPROTO_TCP, TCP_SYNCTNT, 2): %w", syscallErr)
 					return
 				}
 			}
 
+			// IP_TRANSPARENT allows a socket to bind to an IP address that is not
+			// configured on the local machine. This is essential for transparent
+			// This option requires appropriate capabilities (CAP_NET_ADMIN and CAP_NET_RAW)
 			syscallErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, syscall.IP_TRANSPARENT, 1)
 			if syscallErr != nil {
 				syscallErr = fmt.Errorf("setsockopt(IPPROTO_IP, IP_TRANSPARENT, 1): %w", syscallErr)
 				return
 			}
 
+			// SO_REUSEADDR：allows multiple sockets to bind to the same address and port
+			// This is useful for restarting the proxy without waiting for old sockets to time out
 			syscallErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
 			if syscallErr != nil {
 				syscallErr = fmt.Errorf("setsockopt(SOL_SOCKET, SO_REUSEADDR, 1): %w", syscallErr)
 				return
 			}
 
+			//IP_BIND_ADDRESS_NO_PORT（Linux 4.4+）
+			// Allows binding to an IP address without specifying a port
+			// This is useful for transparent proxying scenarios where the original
+			// destination port is not known at bind time
 			if sport == 0 {
 				ipBindAddressNoPort := 24
 				syscallErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_IP, ipBindAddressNoPort, 1)
@@ -63,6 +73,7 @@ func DialUpstreamControl(sport int) func(string, string, syscall.RawConn) error 
 				}
 			}
 
+			//SO_MARK used by iptables to mark packets for routing
 			if Opts.Mark != 0 {
 				syscallErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_MARK, Opts.Mark)
 				if syscallErr != nil {


### PR DESCRIPTION
use io.CopyBuffer in tcpCopyData insted of io.Copy
Thanks again to this project - It makes running a transparent proxy that keeps the source IP easy, and avoids the build headaches of the original `mmproxy`,and simplifies integration into other projects.